### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ the package management library used by pacman and other tools.
 
 # Features
 
-- mtree - enables the alpm_pkg_mtree_* funtions
+- mtree - enables the alpm_pkg_mtree_* functions
 - generate - generate the raw alpm-sys bindings at build time
 - checkver - check that the version of libalpm installed is compatible with alpm.rs
 - git - target the git master API

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ without bumping the major version.
 This crate just provides bindings for libalpm and hence does not document libalpm.
 You can find documentation for libalpm in the [libalpm (3)](https://man.archlinux.org/man/core/pacman/libalpm.3.en) man page or in [alpm.h](https://gitlab.archlinux.org/pacman/pacman/-/blob/master/lib/libalpm/alpm.h).
 
-There are also examples on how to use the alpm create in [alpm/examples](alpm/examples).
+There are also examples on how to use the alpm crate in [alpm/examples](alpm/examples).
 
 # alpm-sys
 


### PR DESCRIPTION
Fixed typo "funtions"