### PR TITLE
Fix API breakage relating to lifetime tweaks and bitflags attributes

### DIFF
--- a/alpm/src/remove.rs
+++ b/alpm/src/remove.rs
@@ -3,7 +3,7 @@ use crate::{Alpm, Package, Result};
 use alpm_sys::*;
 
 impl Alpm {
-    pub fn trans_remove_pkg(&self, pkg: Package) -> Result<()> {
+    pub fn trans_remove_pkg(&self, pkg: &Package) -> Result<()> {
         let ret = unsafe { alpm_remove_pkg(self.as_ptr(), pkg.as_ptr()) };
         self.check_ret(ret)
     }

--- a/alpm/src/trans.rs
+++ b/alpm/src/trans.rs
@@ -12,7 +12,7 @@ use std::ptr;
 use bitflags::bitflags;
 
 bitflags! {
-    #[derive(Debug, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq, Copy, Clone)]
     pub struct TransFlag: u32 {
         const NONE = 0;
         const NO_DEPS = ALPM_TRANS_FLAG_NODEPS;

--- a/alpm/src/types.rs
+++ b/alpm/src/types.rs
@@ -35,7 +35,7 @@ pub enum FetchResult {
 }
 
 bitflags! {
-    #[derive(Debug, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
     pub struct SigLevel: u32 {
         const NONE = 0;
         const PACKAGE = ALPM_SIG_PACKAGE;
@@ -51,7 +51,7 @@ bitflags! {
 }
 
 bitflags! {
-    #[derive(Debug, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
     pub struct Usage: u32 {
         const NONE = 0;
         const SYNC = ALPM_DB_USAGE_SYNC;
@@ -63,7 +63,7 @@ bitflags! {
 }
 
 bitflags! {
-    #[derive(Debug, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
     pub struct LogLevel: u32 {
         const NONE = 0;
         const ERROR = ALPM_LOG_ERROR;
@@ -104,7 +104,7 @@ pub enum PackageReason {
 }
 
 bitflags! {
-    #[derive(Debug, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
     pub struct PackageValidation: u32 {
         const UNKNOWN = ALPM_PKG_VALIDATION_UNKNOWN;
         const NONE = ALPM_PKG_VALIDATION_NONE;


### PR DESCRIPTION
When lifetime annotations were removed from the Package struct, this change necessitated borrowing in code downstream. For example, alpm.rs also returns &Package objects via the pkg function in the Db struct. 

This breaks trans_remove_pkg because the function signature only accepts owned Package objects, which makes it seemingly impossible to use.

Further, the update to bitflags also incurred some breakage downstream in my code with regards to the ergonomics of handling TransFlag bitflags attributes in the alpm.rs API. Without the Copy, Clone attributes derived, the only other option is to convert bitflags into an integer with the bits function, and then parse it back into a unique, owned TransFlag object.

Perhaps modifying trans_init to accept a borrowed TransFlag could also be done?

Herein I've included an initial set of patches to fix both of these issues in the interim.