### PR TITLE
Remove deprecated SPDX License ID from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,5 @@ authors = ["morganamilo <morganamilo@archlinux.org>"]
 edition = "2021"
 homepage = "http://github.com/archlinux/alpm.rs"
 repository = "http://github.com/archlinux/alpm.rs"
-license = "GPL-3.0"
+license = "GPL-3.0-only"
 keywords = ["archlinux", "arch", "alpm", "pacman", "bindings"]


### PR DESCRIPTION
The SPDX license identifier "GPL-3.0" has been deprecated since SPDX license list version 3.0, from December 2017, for being unclear if "GPL 3.0 only" or "GPL 3.0 or any later version" was meant. New crates published on Crates.io will not accept deprecated license identifiers. This PR updates the SPDX short license ID from the deprecated ID "GPL-3.0" to the new and prefered "GPL-3.0-only". Only the SPDX short identifier is being changed in this PR. The actual license remains the same.

Please see below links for additional information:
https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields
https://spdx.dev/license-list-3-0-released/
https://www.gnu.org/licenses/identify-licenses-clearly.html
https://spdx.org/licenses/GPL-3.0.html