### PR TITLE
Fix callback event type to enum variant mapping

### DIFF
--- a/alpm/src/unions.rs
+++ b/alpm/src/unions.rs
@@ -297,7 +297,7 @@ impl<'a> AnyEvent<'a> {
                 marker: PhantomData,
             }),
             EventType::IntegrityStart => Event::IntegrityStart,
-            EventType::IntegrityDone => Event::InterConflictsDone,
+            EventType::IntegrityDone => Event::IntegrityDone,
             EventType::LoadStart => Event::LoadStart,
             EventType::LoadDone => Event::LoadDone,
             EventType::ScriptletInfo => Event::ScriptletInfo(ScriptletInfoEvent {
@@ -333,7 +333,7 @@ impl<'a> AnyEvent<'a> {
                 inner: unsafe { &(*event).hook },
                 marker: PhantomData,
             }),
-            EventType::HookDone => Event::HookStart(HookEvent {
+            EventType::HookDone => Event::HookDone(HookEvent {
                 inner: unsafe { &(*event).hook },
                 marker: PhantomData,
             }),
@@ -341,7 +341,7 @@ impl<'a> AnyEvent<'a> {
                 inner: unsafe { &(*event).hook_run },
                 marker: PhantomData,
             }),
-            EventType::HookRunDone => Event::HookRunStart(HookRunEvent {
+            EventType::HookRunDone => Event::HookRunDone(HookRunEvent {
                 inner: unsafe { &(*event).hook_run },
                 marker: PhantomData,
             }),


### PR DESCRIPTION
Some callback event types mapped to the wrong event enum variant. This change ensures all callback events map to the correct enum variant.